### PR TITLE
typo fix

### DIFF
--- a/lectures/04/README.md
+++ b/lectures/04/README.md
@@ -262,7 +262,7 @@ a growing ecosystem.
 HPC's favourite simple test, saxpy (single precision `a*x + y`)
 
 ```C++
-kokkos::parallel_for(N,
+Kokkos::parallel_for(N,
   KOKKOS_LAMBDA(int i) {
 	y(i) = a * x(i) + y(i);
   });


### PR DESCRIPTION
capital first K for `Kokkos::parallel_for()`
on slide 17, Lecture 4 - C++ frameworks for portable performance